### PR TITLE
V0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 0.5.0 Alpha
+
+Undo/Redo update
+
+### Added
+
+- Undo/Redo control
+- Keybindings for undo & redo
+
+### Changed
+
+- Updated the deck sorter to use a single sorting algorithm
+
+### Fixed
+
+- Fixed a bug in the filter causing the card set filter to remain uncleared when filter is cleared.
+
 ## 0.4.1 Alpha
 
 Small bug fixes
@@ -35,7 +52,7 @@ A big update adding big features.
 - Discord RPC
 - Default keybinding for "open ycb" (Ctrl+Shift+O)
 
-### Changes
+### Changed
 
 - Removed experimental sign from filter in deck editor
 
@@ -48,7 +65,7 @@ This update add some settings and fixes some bugs.
 - About tab in settings
 - Keybindings tab in settings
 
-### Changes
+### Changed
 
 - Updated settings UI
 
@@ -65,7 +82,7 @@ This update brings a few bug fixes and UI improvements.
 
 - Default keybinding for "save as" (Ctrl+Shift+S)
 
-### Changes
+### Changed
 
 - Improved settings menu
 - Documentation changes can now be published without building a new version

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@ Things may be added/removed over time if I change my mind about what should be i
 
 - [x] Settings menu
 - [x] Keyboard shortcut API
-- [ ] Undo/Redo system
+- [x] Undo/Redo system
 - [ ] Context menu when right click on deck or a card in deck
 - [x] Combo Editor (using `.ycb` extension (**Y**u-Gi-Oh! **C**om**b**o))
 - [x] Custom CSS library (iridium.css)

--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
           </select>
         </div>
         <div style="width:33%;float: left;padding: 4px;">
-          <select id="card_set" onchange="filters.update(this)">
+          <select id="card_set" onchange="filters.update(this)" disabled>
             <option value="undefined">Select card set</option>
           </select>
         </div>
@@ -383,7 +383,7 @@
             <input class="ir-flex ir-input" style="margin:2px;float:left;width:50%" id="variant-max" onkeyup="" placeholder="Max" type="number" min="0">
           </div>
           <br>
-          <select id="variant-target" onchange="// TODO">
+          <select id="variant-target">
             <option value="hand">Hand</option>
             <option value="deck">Deck</option>
           </select>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 <body>
   <script src="js/menu.js"></script>
   <script src="js/api.js"></script>
+  <script src="js/undo.js"></script>
   <script src="js/ygoprodeck.js"></script>
   <script src="js/deckeditor.js"></script>
   <script src="js/deck_sorter.js"></script>
@@ -48,8 +49,8 @@
           Edit
         </div>
         <div class="dropdown-content">
-          <a href="#" class="disabled">Undo</a>
-          <a href="#" class="disabled">Redo</a>
+          <a href="#" class="undo disabled">Undo</a>
+          <a href="#" class="redo disabled">Redo</a>
         </div>
       </div>
       <div class="dropdown">
@@ -439,6 +440,12 @@
       </div>
       <div class="ir-flex-row">
         <div>Settings</div><input class="ir-input key-settings">
+      </div>
+      <div class="ir-flex-row">
+        <div>Undo</div><input class="ir-input key-undo">
+      </div>
+      <div class="ir-flex-row">
+        <div>Redo</div><input class="ir-input key-redo">
       </div>
     </div>
     <div class="tab" id="About">

--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
           </select>
         </div>
         <div style="width:33%;float: left;padding: 4px;">
-          <select id="card_set" onchange="filters.update(this)" disabled>
+          <select id="card_set" onchange="filters.update(this)">
             <option value="undefined">Select card set</option>
           </select>
         </div>
@@ -450,7 +450,7 @@
     </div>
     <div class="tab" id="About">
       <h2>About</h2>
-      <p>Version: 0.4.1</p>
+      <p>Version: 0.5.0</p>
       <p>Author: Reuben Tier (AKA TheOtterlord)</p>
       <p>Website: <a href="https://theotterlord.github.io/deckmaster"
           target="_blank">theotterlord.github.io/deckmaster</a></p>

--- a/js/api.js
+++ b/js/api.js
@@ -2,7 +2,7 @@ const { dialog } = require('electron').remote;
 const paths = require('path');
 
 const deckmaster = {
-  version: "v0.4.1",
+  version: "v0.5.0",
   notification: (title, text, onclick) => {
     const notification = new Notification(title, {
       body: text

--- a/js/api.js
+++ b/js/api.js
@@ -148,6 +148,8 @@ const deckmaster = {
     main.clear();
     extra.clear();
     side.clear();
+    deckchanges.clear();
+    deckchanges.default = {main: [], extra: [], side: []};
     combos.splice(0, combos.length);
     updateCombos();
   },
@@ -171,6 +173,8 @@ const deckmaster = {
           main.addCards(deck.main);
           extra.addCards(deck.extra);
           side.addCards(deck.side);
+          deckchanges.clear();
+          deckchanges.default = deck;
           editor.setDeckname(path.split("\\").reverse()[0]);
           editor.setAuthor(deck.author);
           combos.splice(0, combos.length);

--- a/js/deck_sorter.js
+++ b/js/deck_sorter.js
@@ -56,6 +56,7 @@ function sort_deck() {
   extra.addCards(extra_ids);
   side.clear();
   side.addCards(side_ids);
+  deckchanges.push(editor.getDeck());
 }
 
 function type_of(c) {

--- a/js/keybind.js
+++ b/js/keybind.js
@@ -31,7 +31,9 @@ class Keybinder {
       'open_ycb',
       'save',
       'save_as',
-      'settings'
+      'settings',
+      'undo',
+      'redo'
     ];
     to_bind.forEach(bind => {
       document.querySelector(`.key-${bind}`).value = this.stringify(settings.data.keybindings?.[bind]) ?? "";
@@ -77,6 +79,8 @@ class Keybinder {
     });
     this.register({...binds.save_as, callback: deckmaster.saveAs });
     this.register({...binds.settings, callback: open_settings });
+    this.register({...binds.undo, callback: () => deckchanges.undo()});
+    this.register({...binds.redo, callback: () => deckchanges.redo()});
   }
 
   register(binding) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -23,7 +23,9 @@ class Settings {
       open_ycb: {key: "o", ctrl: true, shift: true},
       save: {key: "s", ctrl: true},
       save_as: {key: "s", ctrl: true, shift: true},
-      settings: {key: ",", ctrl: true}
+      settings: {key: ",", ctrl: true},
+      undo: {key: "z", ctrl: true},
+      redo: {key: "y", ctrl: true}
     }, ...old.keybindings ?? {}};
     new_settings.author = old.author ?? "";
     this.save();

--- a/js/undo.js
+++ b/js/undo.js
@@ -1,0 +1,126 @@
+/**
+ * The `Change` class is used to keep track of changes, and allow those changes to be undone/redone.
+ */
+class Change {
+  
+  /**
+   * Creates an instace of `Change`, initializing the stack array, index and event arrays
+   */
+  constructor() {
+    this.clear();
+    this.pushEvents = [];
+    this.undoEvents = [];
+    this.redoEvents = [];
+  }
+
+  /**
+   * Push a new change to the stack.
+   * This overrides any undone changes.
+   * @param {*} item The change to append
+   */
+  push(item) {
+    this.stack.splice(this.index+1);
+    this.stack.push(item);
+    this.index++;
+    for (let i = 0; i < this.pushEvents.length; i++) {
+      this.pushEvents[i](item);
+    }
+  }
+
+  /**
+   * Clear the undo/redo stack and reset the index
+   */
+  clear() {
+    this.stack = [];
+    this.index = -1;
+  }
+
+  /**
+   * Undo the last change in the stack.
+   * @returns {*} The item to be reverted to if possible to undo, otherwise returns undefined
+   */
+  undo() {
+    if (this.canUndo) {
+      this.index--;
+      let item = this.stack[this.index];
+      for (let i = 0; i < this.undoEvents.length; i++) {
+        this.undoEvents[i](item);
+      }
+      return item;
+    }
+  }
+
+  /**
+   * Redo the last undo in the stack.
+   * @returns {*} The item to be redone if possible to redo, otherwise returns undefined
+   */
+  redo() {
+    // if the index is less than the max index
+    if (this.canRedo) {
+      this.index++;
+      let item = this.stack[this.index];
+      for (let i = 0; i < this.redoEvents.length; i++) {
+        this.redoEvents[i](item);
+      }
+      return item;
+    }
+  }
+
+  /**
+   * Undo `i` times.
+   * @param {number} i Number of times to undo
+   * @returns {*[]} An array of all items to be undone
+   */
+  massUndo(i=1) {
+    let undo_stack = [];
+    for (let stop = 0; stop < i; i--) {
+      let item = this.undo();
+      if (item) undo_stack.push(item);
+      else break;
+    }
+    return undo_stack;
+  }
+
+  /**
+   * Redo `i` times.
+   * @param {number} i Number of times to Redo
+   * @returns {*[]} An array of all items to be redone
+   */
+  massRedo(i=1) {
+    let redo_stack = [];
+    for (let stop = 0; stop < i; i--) {
+      let item = this.redo();
+      if (item) redo_stack.push(item);
+      else break;
+    }
+    return redo_stack;
+  }
+
+  on(event, callback) {
+    if      (event == "push") this.pushEvents.push(callback);
+    else if (event == "undo") this.undoEvents.push(callback);
+    else if (event == "redo") this.redoEvents.push(callback);
+    else return Error(`No event called '${event}';`);
+  }
+
+  /**
+   * @returns {boolean} If you can undo a change
+   */
+  get canUndo() {
+    return this.index >= 0;
+  }
+
+  /**
+   * @returns {boolean} If you can redo a change
+   */
+  get canRedo() {
+    return this.index < this.stack.length-1;
+  }
+
+  /**
+   * @returns {*} Gets the last change to happen (or be reverted to), or `undefined` if no changes have been made
+   */
+  get current() {
+    return this.stack[this.index];
+  }
+}

--- a/js/ygoprodeck.js
+++ b/js/ygoprodeck.js
@@ -244,7 +244,6 @@ const filters = {
         document.querySelector("#level").disabled = undefined;
         document.querySelector("#scale").disabled = undefined;
         document.querySelector("#attribute").disabled = undefined;
-        document.querySelector("#card_set").disabled = undefined;
       } else {
         document.querySelector("#race").selectedIndex = 0;
         filters.race = undefined;
@@ -265,7 +264,6 @@ const filters = {
         filters.attribute = undefined;
         document.querySelector("#attribute").disabled = "true";
         filters.card_set = undefined;
-        document.querySelector("#card_set").disabled = "true";
         document.querySelector("#card_set").selectedIndex = 0;
       }
       if (el.value == "undefined") {

--- a/js/ygoprodeck.js
+++ b/js/ygoprodeck.js
@@ -244,6 +244,7 @@ const filters = {
         document.querySelector("#level").disabled = undefined;
         document.querySelector("#scale").disabled = undefined;
         document.querySelector("#attribute").disabled = undefined;
+        document.querySelector("#card_set").disabled = undefined;
       } else {
         document.querySelector("#race").selectedIndex = 0;
         filters.race = undefined;
@@ -263,6 +264,9 @@ const filters = {
         document.querySelector("#attribute").selectedIndex = 0;
         filters.attribute = undefined;
         document.querySelector("#attribute").disabled = "true";
+        filters.card_set = undefined;
+        document.querySelector("#card_set").disabled = "true";
+        document.querySelector("#card_set").selectedIndex = 0;
       }
       if (el.value == "undefined") {
         document.querySelector("#cardtype").selectedIndex = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deckmaster",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A Yu-Gi-Oh! TCG deck editor",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Undo/Redo update

### Added

- Undo/Redo control
- Keybindings for undo & redo

### Changed

- Updated the deck sorter to use a single sorting algorithm

### Fixed

- Fixed a bug in the filter causing the card set filter to remain uncleared when filter is cleared.
